### PR TITLE
Add link to Compliance Info document

### DIFF
--- a/devkits/clara-agx/clara_agx_user_guide.md
+++ b/devkits/clara-agx/clara_agx_user_guide.md
@@ -602,4 +602,4 @@ For feedback, discussion, and questions, please post to the Clara Holoscan SDK [
 
 ## Compliance Information
 
-Please refer to NVIDIA compliance information.
+Please refer to [Clara AGX Developer Kit Compliance Information](https://developer.nvidia.com/clara-agx-developer-kit-compliance-information) documentation.


### PR DESCRIPTION
Updated the Compliance Info section in Clara AGX user guide to have link to Compliance Info document.