### PR TITLE
[CAGX] Driver update fix

### DIFF
--- a/devkits/clara-agx/clara_agx_user_guide.md
+++ b/devkits/clara-agx/clara_agx_user_guide.md
@@ -609,7 +609,7 @@ Please refer to [Clara AGX Developer Kit Compliance Information](https://develop
 
 ### Install CUDA APT keyring
 
-```sh
+```bash
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/sbsa/cuda-keyring_1.1-1_all.deb
 sudo apt install ./cuda-keyring_1.1-1_all.deb
 rm ./cuda-keyring_1.1-1_all.deb
@@ -618,16 +618,16 @@ sudo apt-get update
 
 ### Install drivers
 
-535 is the LTS version, but you can also install any other version from `apt policy cuda-drivers`, or just `cuda-drivers` for the latest available version:
+`535` is the LTS version, but you can also install any other version shown by `apt policy cuda-drivers`, or just `cuda-drivers` with no version string to install the latest drivers:
 
-```sh
+```bash
 sudo apt install cuda-drivers="535.*"
 sudo reboot
 ```
 
-> **Note:** if you'd like to install the open kernel module flavor, you'll still need to list `cuda-drivers` package, as following [the regular instructions to switch flavor](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/#switching-between-driver-module-flavors) would uninstall the L4T BSP packages which depend on `cuda-drivers` explicitly.
+> **Note:** if you'd like to install the open kernel module flavor, you'll still need to list the `cuda-drivers` package, as following [the regular instructions to switch flavor](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/#switching-between-driver-module-flavors) would uninstall the L4T BSP packages which depend on `cuda-drivers` explicitly.
 >
-> ```sh
+> ```bash
 > # Example for 560 drivers
 > sudo apt install cuda-drivers="560.*" nvidia-driver-560-open
 > sudo reboot
@@ -637,7 +637,25 @@ sudo reboot
 
 ### Validate Version
 
-```sh
-nvidia-smi
-# driver version only: nvidia-smi -i 0 --query-gpu=driver_version --format=csv,noheader
+Run `nvidia-smi` after reboot to confirm your driver version.
+
+```
++---------------------------------------------------------------------------------------+
+| NVIDIA-SMI 535.183.06             Driver Version: 535.183.06   CUDA Version: 12.2     |
+|-----------------------------------------+----------------------+----------------------+
+| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
+| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
+|                                         |                      |               MIG M. |
+|=========================================+======================+======================|
+|   0  Quadro RTX 6000                On  | 00000000:09:00.0  On |                  Off |
+| 33%   34C    P8              16W / 260W |     51MiB / 24576MiB |      1%      Default |
+|                                         |                      |                  N/A |
++-----------------------------------------+----------------------+----------------------+
+```
+
+To print the driver version only, you can run:
+
+```bash
+$ nvidia-smi --query-gpu=driver_version --format=csv,noheader
+535.183.06
 ```

--- a/devkits/clara-agx/clara_agx_user_guide.md
+++ b/devkits/clara-agx/clara_agx_user_guide.md
@@ -606,22 +606,38 @@ For feedback, discussion, and questions, please post to the Clara Holoscan SDK [
 Please refer to [Clara AGX Developer Kit Compliance Information](https://developer.nvidia.com/clara-agx-developer-kit-compliance-information) documentation.
 
 ## Update Nvidia drivers
- Download driver from:
- https://www.nvidia.com/download/driverResults.aspx/226780/en-us/
 
-##### Unpack deb
-```sh
-sudo cp /var/nvidia-driver-local-repo-ubuntu2004-550.90.07/nvidia-driver-local-E3AF38C2-keyring.gpg /usr/share/keyrings/
-sudo dpkg -i nvidia-driver-local-repo-ubuntu2004-550.90.07_1.0-1_arm64.deb 
-```
+### Install CUDA APT keyring
 
-##### Install keyring
 ```sh
-wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/arm64/cuda-keyring_1.1-1_all.deb 
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/sbsa/cuda-keyring_1.1-1_all.deb
 sudo apt install ./cuda-keyring_1.1-1_all.deb
+rm ./cuda-keyring_1.1-1_all.deb
+sudo apt-get update
 ```
-##### Install and reboot
-```
-sudo apt install cuda-drivers-550
+
+### Install drivers
+
+535 is the LTS version, but you can also install any other version from `apt policy cuda-drivers`, or just `cuda-drivers` for the latest available version:
+
+```sh
+sudo apt install cuda-drivers="535.*"
 sudo reboot
+```
+
+> **Note:** if you'd like to install the open kernel module flavor, you'll still need to list `cuda-drivers` package, as following [the regular instructions to switch flavor](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/#switching-between-driver-module-flavors) would uninstall the L4T BSP packages which depend on `cuda-drivers` explicitly.
+>
+> ```sh
+> # Example for 560 drivers
+> sudo apt install cuda-drivers="560.*" nvidia-driver-560-open
+> sudo reboot
+> ```
+> 
+> For `535` that is even more tricky, as the CUDA APT repository does not include the `nvidia-driver-535-open` package. It is available from Canonical/Ubuntu servers instead, but with strict dependencies versions that precede what the NVIDIA repository provides (`535.183.01-0ubuntu0.20.04.1` instead of `535.183.06-0ubuntu1`) and APT cannot resolve it automatically and will error out with `Unmet dependencies` when running the command above. If you must use `535-open`, explicitly add all the dependencies listed by `Unmet dependencies / Depends:` suffixed with `=="535.183.01-0ubuntu0.20.04.1"` to your `apt install` command.
+
+### Validate Version
+
+```sh
+nvidia-smi
+# driver version only: nvidia-smi -i 0 --query-gpu=driver_version --format=csv,noheader
 ```

--- a/devkits/clara-agx/clara_agx_user_guide.md
+++ b/devkits/clara-agx/clara_agx_user_guide.md
@@ -635,6 +635,23 @@ sudo reboot
 > 
 > For `535` that is even more tricky, as the CUDA APT repository does not include the `nvidia-driver-535-open` package. It is available from Canonical/Ubuntu servers instead, but with strict dependencies versions that precede what the NVIDIA repository provides (`535.183.01-0ubuntu0.20.04.1` instead of `535.183.06-0ubuntu1`) and APT cannot resolve it automatically and will error out with `Unmet dependencies` when running the command above. If you must use `535-open`, explicitly add all the dependencies listed by `Unmet dependencies / Depends:` suffixed with `=="535.183.01-0ubuntu0.20.04.1"` to your `apt install` command.
 
+**Known Limitation**: If you run into an error like this:
+
+   ```
+   Depends: cuda-drivers-XXX (>= XXX.YYY.ZZZ) but it is not going to be installed
+   ```
+
+Try to upgrade your current drivers to the latest minor version before upgrading the major version:
+
+   ```bash
+   # Example: if you are on 535.161.08 and want to upgrade to 560, you might need to upgrade to the latest 535 first
+   sudo apt install cuda-drivers="535.*"
+
+   # Now try upgrading to 560 again
+   sudo apt install cuda-drivers="560.*" nvidia-driver-560-open
+   sudo reboot
+   ```
+
 ### Validate Version
 
 Run `nvidia-smi` after reboot to confirm your driver version.


### PR DESCRIPTION
Preview: https://github.com/nvidia-holoscan/holoscan-docs/blob/ag/fix-driver-update-cagx/devkits/clara-agx/clara_agx_user_guide.md#update-nvidia-drivers

____

### 1. Instructions mixed install from local repo + remote repo

stick to remote repo only

____

### 2. Current instructions do not work:

```sh
$ sudo apt install cuda-drivers-550
Reading package lists... Done
Building dependency tree
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 cuda-drivers-550 : Depends: nvidia-driver-550 (>= 550.90.12) but it is not going to be installed or
                             nvidia-driver-550-open (>= 550.90.12) but it is not going to be installed or
                             nvidia-driver-550-server (>= 550.90.12) but it is not going to be installed or
                             nvidia-driver-550-server-open (>= 550.90.12) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

Probably worked because it was the latest version at the time it was written

Fix by updating instructions to install `cuda-drivers` instead (which can be versioned)

____

### 3. Add instructions for download open kernel flavors

Was tricky due to removal of nvidia-l4t BSP packages with [regular instructions](https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/#switching-between-driver-module-flavors), as well as version mismatch for 535 due to open package hosted on canonical only.